### PR TITLE
Make Auth0 and Okta successfully create Lambda

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,10 @@ vendor. E.g `hd` is not required if you are using the `github` auth vendor.
 |------|-------------|:----:|:-----:|:-----:|
 | github_organization | The github organization that owns the auth application | string | `` | yes |
 
+** Auth0, Okta **
+| Name | Description | Type | Default | Required |
+| base_url | The URL of your Authorization tenant for Auth0 and Okta | string | `` | yes |
+
 
 ### Standard
 

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ vendor. E.g `hd` is not required if you are using the `github` auth vendor.
 
 ** Auth0, Okta **
 | Name | Description | Type | Default | Required |
-| base_url | The URL of your Authorization tenant for Auth0 and Okta | string | `` | yes |
+| base_url | The URL of your Authorization tenant for Auth0 and Okta. This must begin with http(s). | string | `` | yes |
 
 
 ### Standard

--- a/README.md
+++ b/README.md
@@ -96,8 +96,10 @@ vendor. E.g `hd` is not required if you are using the `github` auth vendor.
 |------|-------------|:----:|:-----:|:-----:|
 | github_organization | The github organization that owns the auth application | string | `` | yes |
 
-** Auth0, Okta **
+**Auth0 and Okta**
+
 | Name | Description | Type | Default | Required |
+|------|-------------|:----:|:-----:|:-----:|
 | base_url | The URL of your Authorization tenant for Auth0 and Okta. This must begin with http(s). | string | `` | yes |
 
 

--- a/locals.tf
+++ b/locals.tf
@@ -9,7 +9,7 @@ locals {
   build_lambda_command_plus_hd = var.auth_vendor == "google" ? "${chomp(local.build_lambda_command_common)} --HD=${format("%q", var.hd)}" : local.build_lambda_command_common
 
   build_lambda_command_common = <<-EOT
-    cd build/cloudfront-auth-master && node build/build.js --AUTH_VENDOR='${var.auth_vendor}' --CLOUDFRONT_DISTRIBUTION='${var.cloudfront_distribution}' --CLIENT_ID='${var.client_id}' --CLIENT_SECRET='${var.client_secret}' --REDIRECT_URI='${var.redirect_uri}' --SESSION_DURATION='${var.session_duration}' --AUTHZ=${format("%q", var.authz)}
+    cd build/cloudfront-auth-master && node build/build.js --AUTH_VENDOR='${var.auth_vendor}' --CLOUDFRONT_DISTRIBUTION='${var.cloudfront_distribution}' --CLIENT_ID='${var.client_id}' --CLIENT_SECRET='${var.client_secret}' --REDIRECT_URI='${var.redirect_uri}' --SESSION_DURATION='${var.session_duration}' --AUTHZ=${format("%q", var.authz)} --BASE_URL='${var.base_url}'
     EOT
 }
 

--- a/main.tf
+++ b/main.tf
@@ -242,7 +242,7 @@ resource "aws_lambda_function" "default" {
   runtime          = "nodejs12.x"
   role             = aws_iam_role.lambda_role.arn
   filename         = local.lambda_filename
-  function_name    = "${var.cloudfront_distribution}-cloudfront_auth"
+  function_name    = "${replace(var.cloudfront_distribution,".","-")}-cloudfront_auth"
   handler          = "index.handler"
   publish          = true
   timeout          = 5

--- a/main.tf
+++ b/main.tf
@@ -45,8 +45,8 @@ data "local_file" "build-js" {
   filename = "${path.module}/build.js"
 }
 
-data "local_file" "distribution-zip" {
-  filename = "${path.module}/build/cloudfront-auth-master/distributions/${var.cloudfront_distribution}/${var.cloudfront_distribution}.zip"
+data "local_file" "distribution_zip" {
+  filename = "${path.root}/build/cloudfront-auth-master/distributions/${var.cloudfront_distribution}/${var.cloudfront_distribution}.zip"
   depends_on = [null_resource.build_lambda]
 }
 
@@ -227,15 +227,14 @@ resource "aws_lambda_function" "default" {
   description      = "Managed by Terraform"
   runtime          = "nodejs12.x"
   role             = aws_iam_role.lambda_role.arn
-  filename         = local.lambda_filename
+  filename         = data.local_file.distribution_zip.filename
   function_name    = "${replace(var.cloudfront_distribution,".","_")}_cloudfront_auth"
   handler          = "index.handler"
   publish          = true
   timeout          = 5
-  source_code_hash = filebase64sha256(data.local_file.distribution_zip)
+  source_code_hash = filebase64sha256(data.local_file.distribution_zip.filename)
   tags             = var.tags
 
-  depends_on = [null_resource.copy_lambda_artifact]
 }
 
 data "aws_iam_policy_document" "lambda_assume_role" {

--- a/main.tf
+++ b/main.tf
@@ -242,7 +242,7 @@ resource "aws_lambda_function" "default" {
   runtime          = "nodejs12.x"
   role             = aws_iam_role.lambda_role.arn
   filename         = local.lambda_filename
-  function_name    = "cloudfront_auth"
+  function_name    = "${var.cloudfront_distribution}-cloudfront_auth"
   handler          = "index.handler"
   publish          = true
   timeout          = 5
@@ -273,7 +273,7 @@ data "aws_iam_policy_document" "lambda_assume_role" {
 }
 
 resource "aws_iam_role" "lambda_role" {
-  name               = "lambda_role"
+  name               = "${var.cloudfront_distribution}-lambda-auth-role"
   assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
 }
 

--- a/main.tf
+++ b/main.tf
@@ -33,6 +33,7 @@ resource "null_resource" "build_lambda" {
     session_duration        = var.session_duration
     authz                   = var.authz
     github_organization     = try(var.github_organization, "")
+    base_url                = var.base_url
   }
 
   provisioner "local-exec" {

--- a/main.tf
+++ b/main.tf
@@ -18,8 +18,9 @@ resource "null_resource" "build_lambda" {
     github_organization     = try(var.github_organization, "")
     base_url                = var.base_url
     dest_file               = "${path.root}/build/cloudfront-auth-master/distributions/${var.cloudfront_distribution}/${var.cloudfront_distribution}.zip"
+    zip_refresh             = fileexists("${path.root}/build/cloudfront-auth-master/distributions/${var.cloudfront_distribution}/${var.cloudfront_distribution}.zip") ? false : timestamp()
   }
-  
+
   provisioner "local-exec" {
     command = <<EOF
 if [ ! -d "build" ]; then
@@ -226,7 +227,7 @@ resource "aws_lambda_function" "default" {
   runtime          = "nodejs12.x"
   role             = aws_iam_role.lambda_role.arn
   filename         = data.local_file.distribution_zip.filename
-  function_name    = "${replace(var.cloudfront_distribution,".","_")}_cloudfront_auth"
+  function_name    = "${replace(var.cloudfront_distribution, ".", "_")}_cloudfront_auth"
   handler          = "index.handler"
   publish          = true
   timeout          = 5

--- a/main.tf
+++ b/main.tf
@@ -285,6 +285,6 @@ resource "aws_iam_role_policy_attachment" "lambda_log_access" {
 
 # Create an IAM policy that will be attached to the role
 resource "aws_iam_policy" "lambda_log_access" {
-  name   = "cloudfront_auth_lambda_log_access"
+  name   = "${var.cloudfront_distribution}-cloudfront_auth_lambda_log_access"
   policy = data.aws_iam_policy_document.lambda_log_access.json
 }

--- a/variables.tf
+++ b/variables.tf
@@ -33,7 +33,7 @@ variable "hd" {
 
 variable "base_url" {
   type        = string
-  description = "The base URL of your auth provider. Applicable to Auth0 and Okta"
+  description = "The base URL of your auth provider. Applicable to Auth0 and Okta. This must begin with http(s)."
   default     = null
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -6,7 +6,7 @@ variable "auth_vendor" {
 
 variable "cloudfront_distribution" {
   type        = string
-  description = "The cloudfront distribtion"
+  description = "The cloudfront distribution"
 }
 
 variable "client_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "hd" {
   default     = null
 }
 
+variable "base_url" {
+  type        = string
+  description = "The base URL of your auth provider. Applicable to Auth0 and Okta"
+  default     = null
+}
+
 variable "session_duration" {
   type        = number
   default     = 1
@@ -40,7 +46,7 @@ variable "session_duration" {
 variable "authz" {
   type        = string
   default     = "1"
-  description = "The authorisation method (google, microsoft only). Mirosoft: (1) Azure AD Login (default)\n   (2) JSON Username Lookup\n\n Google: (1) Hosted Domain - verify email's domain matches that of the given hosted domain\n   (2) HTTP Email Lookup - verify email exists in JSON array located at given HTTP endpoint\n   (3) Google Groups Lookup - verify email exists in one of given Google Groups"
+  description = "The authorization method (google, microsoft only). Mirosoft: (1) Azure AD Login (default)\n   (2) JSON Username Lookup\n\n Google: (1) Hosted Domain - verify email's domain matches that of the given hosted domain\n   (2) HTTP Email Lookup - verify email exists in JSON array located at given HTTP endpoint\n   (3) Google Groups Lookup - verify email exists in one of given Google Groups"
 }
 
 variable "github_organization" {


### PR DESCRIPTION
For Auth0 and Okta providers, the original cloudfront-auth library needs a BASE_URL because the providers give you a tenant specific URL. This is what causes this module to not work with either of those providers. 

Inside this pull request:

- Addition of base_url variable so Auth0, Okta and any other OIDC provider works
- Adding to the docs
- Namespacing the lambda roles and name so you can use this multiple times in the same region.
- No longer copies the lambda code out of the build folder. The script was copying them as the same name so one could overwrite the other. Also, there's no need to do this when the file is easily accessible in the build folder.